### PR TITLE
Fix division import for Holyrood title formatting

### DIFF
--- a/functions/reddit.js
+++ b/functions/reddit.js
@@ -26,7 +26,7 @@ async function findDivisionByUrl(url) {
     let division = null;
     try {
         division = new Division(
-            await r.getSubmission(submissionId).fetch().then(s => s.title.split(' - ')[0]),
+            await r.getSubmission(submissionId).fetch().then(s => s.title.split(' | ')[0]),
             await r.getSubmission(submissionId).fetch().then(s => s.url),
             await r.getSubmission(submissionId).fetch().then(s => s.comments.map(c => [c.author.name, parseVote(c.body)])),
         );


### PR DESCRIPTION
Holyrood uses | as a spacer in titles rather than - like in Westminster, for some reason. 

I'll do a future fix in the main repo that can do both at once in case someone changes it again. 